### PR TITLE
[ci] Use Coveralls action instead of Python package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install -vvv
-          poetry add -D coveralls
           poetry run pip install -r requirements_dev.txt
 
       - name: Lint with flake8
@@ -47,5 +46,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd tests
-          poetry run coverage run --source=perceval.backends.public_inbox run_tests.py
-          poetry run coveralls --service=github
+          poetry run coverage run --source=perceval.backends.topicbox run_tests.py
+      
+      - name: Coveralls
+        uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
+        with:
+          coverage-reporter-version: "v0.6.9"
+          flag-name: run ${{ join(matrix.*, ' - ') }}
+          parallel: true


### PR DESCRIPTION
The Coveralls Python package was updated after 3 years, and it now fails because it does not support Python 3.13. This conflicts with the pyproject configuration, which specifies Python = ^3.8. Use the Coveralls GitHub action instead to align with other repositories.